### PR TITLE
Allow building onto an identical branch

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -11,9 +11,9 @@ function fmt() {
 }
 
 function execSync(cmd, error, noOutput) {
-  var exec = shell.exec(cmd, {silent: true});
-
   debug('exec `%s`: ...', cmd);
+
+  var exec = shell.exec(cmd, {silent: true});
 
   exec.output = exec.output.trim();
 
@@ -26,7 +26,16 @@ function execSync(cmd, error, noOutput) {
   }
 
   console.log('Running `%s`', cmd);
+
+  // git on success may still write messages to stderr, and shelljs combines
+  // stdout and stderr (sucky). This effect commit-tree, for example, when dest
+  // branch and HEAD are the same, the first output line is 'error: duplicate
+  // parent ... ignored\n', but the command succeeds, and the SHA of the tree is
+  // the next line. So, remove any error lines from output if the command
+  // exited with success.
   if (!noOutput && exec.output.length > 0) {
+    exec.output = exec.output.replace(/error: .*\n/, '', 'g');
+
     console.log('  => %s', exec.output);
   }
 

--- a/test/test-onto.js
+++ b/test/test-onto.js
@@ -55,7 +55,10 @@ function commit(_, callback) {
   });
 }
 
-vasync.pipeline({funcs: [onto, commit]}, function(er) {
+// Note we run onto twice, one to prove we can do it onto a branch with a
+// different head than ours, and the next time to prove we can do it onto a
+// branch with the same head as ours.
+vasync.pipeline({funcs: [onto, onto, commit]}, function(er) {
   assert.ifError(er);
   ok = true;
 });


### PR DESCRIPTION
This means stripping an error message from a command that otherwise
succeeded. Without this, a command line that includes spaces and a
newline is passed to shelljs, which then hangs.
