### PR TITLE
WIP: support older versions of git where possible

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -48,9 +48,10 @@ function execSync(cmd, error, noOutput) {
 function resolveBranch(name) {
   // Resolve symbolic name "HEAD" if given
   if (name === 'HEAD') {
-    name = shell.exec('git symbolic-ref --short HEAD', { silent: true })
+    name = shell.exec('git symbolic-ref HEAD', { silent: true })
                 .output
-                .trim();
+                .trim()
+                .replace(/^refs\/heads\//, '');
   }
 
   // $ git show-ref --heads master


### PR DESCRIPTION
- [x] don't rely on `--short` flag for `git-symbolic-ref`
- [ ] audit for other modern git usage that isn't available in CentOS 6.5

Reported in strongloop/strongloop#173
