### PR TITLE
Add --npm and --git options

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,23 +172,25 @@ the `--onto BRANCH` modifier to the commit command.
 ## Usage
 
 ```
-usage: sl-build.js [options]
+usage: sl-build [options]
 
 Build a node application package.
 
 With no options, the default depends on whether a git repository is
 detected or not.
 
-If a git repository is detected, the default is to install and commit
-the build results to the "deploy" branch, which will be created if it
-does not already exist.
+If a git repository is detected the default is `--git`: install and commit the
+build results to the "deploy" branch, which will be created if it does not
+already exist.
 
-If no git repository is detected, the default is to bundle, install,
-and pack the build results into a `<package-name>-<version>.tgz` file.
+If no git repository is detected the default is `--npm`: bundle, install, and
+pack the build results into a `<package-name>-<version>.tgz` file.
 
 Options:
   -h,--help       Print this message and exit.
   -v,--version    Print version and exit.
+  -n,--npm        Same as `--install --bundle --pack`.
+  -g,--git        Same as `--install --commit`.
   -i,--install    Install dependencies (without scripts, by default).
   --scripts       If installing, run scripts (to build addons).
   -b,--bundle     Modify package to bundle deployment dependencies.

--- a/index.js
+++ b/index.js
@@ -64,6 +64,8 @@ exports.build = function build(argv, callback) {
   var parser = new Parser([
       ':v(version)',
       'h(help)',
+      'n(npm)',
+      'g(git)',
       's(scripts)',
       'i(install)',
       'b(bundle)',
@@ -89,6 +91,16 @@ exports.build = function build(argv, callback) {
       case 'h':
         printHelp($0, console.log);
         return callback();
+      case 'n':
+        install = true;
+        commit = false;
+        bundle = pack = true;
+        break;
+      case 'g':
+        install = true;
+        commit = true;
+        bundle = pack = false;
+        break;
       case 's':
         scripts = true;
         break;

--- a/sl-build.txt
+++ b/sl-build.txt
@@ -5,16 +5,18 @@ Build a node application package.
 With no options, the default depends on whether a git repository is
 detected or not.
 
-If a git repository is detected, the default is to install and commit
-the build results to the "deploy" branch, which will be created if it
-does not already exist.
+If a git repository is detected the default is `--git`: install and commit the
+build results to the "deploy" branch, which will be created if it does not
+already exist.
 
-If no git repository is detected, the default is to bundle, install,
-and pack the build results into a `<package-name>-<version>.tgz` file.
+If no git repository is detected the default is `--npm`: bundle, install, and
+pack the build results into a `<package-name>-<version>.tgz` file.
 
 Options:
   -h,--help       Print this message and exit.
   -v,--version    Print version and exit.
+  -n,--npm        Same as `--install --bundle --pack`.
+  -g,--git        Same as `--install --commit`.
   -i,--install    Install dependencies (without scripts, by default).
   --scripts       If installing, run scripts (to build addons).
   -b,--bundle     Modify package to bundle deployment dependencies.

--- a/test/test-basic.sh
+++ b/test/test-basic.sh
@@ -33,13 +33,13 @@ BEFORE_HEAD=`git show-ref -s --head HEAD`
 BEFORE_DST=`git show-ref -s --heads dst`
 
 touch build.out
-node ../../bin/slb --commit --onto dst
+node ../../bin/sl-build --commit --onto dst
 
 AFTER_DST=`git show-ref -s --heads dst`
 AFTER_HEAD=`git show-ref -s --head HEAD`
 
-test "$BEFORE_HEAD" == "$AFTER_HEAD" || die 'slb should not modify HEAD'
-test "$BEFORE_DST" != "$AFTER_DST" || die 'slb should modify --onto branch'
+test "$BEFORE_HEAD" == "$AFTER_HEAD" || die 'sl-build should not modify HEAD'
+test "$BEFORE_DST" != "$AFTER_DST" || die 'sl-build should modify --onto branch'
 
 git cat-file -e master:build.out 2> /dev/null && die 'build.out should not exist on master'
 git cat-file -e dst:build.out || die 'build.out should exist on dst'
@@ -47,30 +47,30 @@ git cat-file -e dst:build.out || die 'build.out should exist on dst'
 BEFORE_HEAD=`git show-ref -s --head HEAD`
 BEFORE_DST=`git show-ref -s --heads dst`
 
-node ../../bin/slb --commit --onto dst
+node ../../bin/sl-build --commit --onto dst
 
 AFTER_DST=`git show-ref -s --heads dst`
 AFTER_HEAD=`git show-ref -s --head HEAD`
 
 echo "BH $BEFORE_HEAD BD $BEFORE_DST AH $AFTER_HEAD AD $AFTER_DST"
-test "$BEFORE_HEAD" == "$AFTER_HEAD" || die 'slb should not modify HEAD'
-test "$BEFORE_DST" == "$AFTER_DST" || die 'slb should not modify --onto branch if nothing changed'
+test "$BEFORE_HEAD" == "$AFTER_HEAD" || die 'sl-build should not modify HEAD'
+test "$BEFORE_DST" == "$AFTER_DST" || die 'sl-build should not modify --onto branch if nothing changed'
 
 BEFORE_HEAD=`git show-ref -s --head HEAD`
 BEFORE_DST=`git show-ref -s --heads dst`
 BEFORE_SRC=`git show-ref -s --heads src`
 
 touch build2.out
-node ../../bin/slb --commit --onto HEAD || die 'Failed to deploy to current branch'
+node ../../bin/sl-build --commit --onto HEAD || die 'Failed to deploy to current branch'
 
 AFTER_SRC=`git show-ref -s --heads src`
 AFTER_DST=`git show-ref -s --heads dst`
 AFTER_HEAD=`git show-ref -s --head HEAD`
 
 echo "BH $BEFORE_HEAD BD $BEFORE_DST AH $AFTER_HEAD AD $AFTER_DST"
-test "$BEFORE_HEAD" != "$AFTER_HEAD" || die 'slb should modify HEAD if used for deploy'
-test "$BEFORE_SRC" != "$AFTER_SRC" || die 'slb should modify branch HEAD pointed to'
-test "$BEFORE_DST" == "$AFTER_DST" || die 'slb should NOT modify other branches'
+test "$BEFORE_HEAD" != "$AFTER_HEAD" || die 'sl-build should modify HEAD if used for deploy'
+test "$BEFORE_SRC" != "$AFTER_SRC" || die 'sl-build should modify branch HEAD pointed to'
+test "$BEFORE_DST" == "$AFTER_DST" || die 'sl-build should NOT modify other branches'
 
 git cat-file -e master:build2.out 2> /dev/null && die 'build.out should not exist on master'
 git cat-file -e dst:build2.out 2> /dev/null && die 'build.out should not exist on dst'
@@ -80,12 +80,12 @@ BEFORE_HEAD=`git show-ref -s --head HEAD`
 BEFORE_DST=`git show-ref -s --heads dst`
 BEFORE_SRC=`git show-ref -s --heads src`
 
-node ../../bin/slb --commit --onto HEAD || die 'Failed to deploy to current branch'
+node ../../bin/sl-build --commit --onto HEAD || die 'Failed to deploy to current branch'
 
 AFTER_SRC=`git show-ref -s --heads src`
 AFTER_DST=`git show-ref -s --heads dst`
 AFTER_HEAD=`git show-ref -s --head HEAD`
 
-test "$BEFORE_HEAD" == "$AFTER_HEAD" || die 'slb should modify HEAD if used for deploy'
-test "$BEFORE_SRC" == "$AFTER_SRC" || die 'slb should modify branch HEAD pointed to'
-test "$BEFORE_DST" == "$AFTER_DST" || die 'slb should NOT modify other branches'
+test "$BEFORE_HEAD" == "$AFTER_HEAD" || die 'sl-build should modify HEAD if used for deploy'
+test "$BEFORE_SRC" == "$AFTER_SRC" || die 'sl-build should modify branch HEAD pointed to'
+test "$BEFORE_DST" == "$AFTER_DST" || die 'sl-build should NOT modify other branches'


### PR DESCRIPTION
If you want to do the normal action for git/npm, even though it isn't
the default (because you are or are not in a git repo), its hard to
remember that -ibp is for npm... introduce shorthands.

@rmg Something I wished for when doing the webinar on strong-pm