### PR TITLE
switch to iconv for binary tests

### DIFF
--- a/test/fixtures/suite/package.json
+++ b/test/fixtures/suite/package.json
@@ -18,7 +18,7 @@
     "weighted": "~0.2.2",
     "shuffle": "~0.2.1",
     "text-table": "~0.2.0",
-    "strong-fork-syslog": "^1.2.1"
+    "iconv": "^2.1.10"
   },
   "optionalDependencies": {
     "loopback-connector-mongodb": "~1.4.1",

--- a/test/test-build-bundle-scripts.js
+++ b/test/test-build-bundle-scripts.js
@@ -11,14 +11,14 @@ build('suite', ['--install', '--pack', '--bundle', '--scripts'], function(er) {
   var info = fs.readJsonSync('package.json');
   var tgz = path.join('..', util.format('%s-%s.tgz', info.name, info.version));
 
-  // strong-fork-syslog build directory should be present
+  // iconv build directory should be present
 
   tar.list(tgz, function(er, paths) {
-    var syslogBuildPaths = paths.filter(function(file) {
-      return file.match(/strong-fork-syslog\/build/);
+    var iconvBuildPaths = paths.filter(function(file) {
+      return file.match(/iconv\/build/);
     });
 
-    debug('tarfile %s contains syslog build dirs:', tgz, syslogBuildPaths);
-    assert(syslogBuildPaths.length > 0);
+    debug('tarfile %s contains iconv build dirs:', tgz, iconvBuildPaths);
+    assert(iconvBuildPaths.length > 0);
   });
 });

--- a/test/test-script-only.js
+++ b/test/test-script-only.js
@@ -19,10 +19,10 @@ require('./build-example')('suite', ['--scripts'], function(er) {
 
   assert(bundled.length > 0, 'dependencies should be bundled');
 
-  var syslogBuildPaths = paths.filter(function(file) {
-    return file.match(/strong-fork-syslog\/build/);
+  var iconvBuildPaths = paths.filter(function(file) {
+    return file.match(/iconv\/build/);
   });
 
-  debug('git branch contains syslog build dirs:', syslogBuildPaths);
-  assert(syslogBuildPaths.length > 0, 'build scripts should be present');
+  debug('git branch contains iconv build dirs:', iconvBuildPaths);
+  assert(iconvBuildPaths.length > 0, 'build scripts should be present');
 });


### PR DESCRIPTION
For some reason the iconv module maintainer seems to be a lot faster
with updating for breaking changes in node and iojs ;-)