### PR TITLE
fix failing test on npm3

### DIFF
--- a/test/test-build-install-nodeps.js
+++ b/test/test-build-install-nodeps.js
@@ -1,9 +1,12 @@
 var assert = require('assert');
 var debug = require('debug')('strong-build:test');
+var find = require('shelljs').find;
 var test = require('shelljs').test;
 
 require('./build-example')('zero-dependency', ['-i'], function(er) {
   debug('built with error?', er);
   assert.ifError(er);
-  assert(!test('-d', 'node_modules'), 'no node_modules created');
+  if (test('-d', 'node_modules')) {
+    assert.deepEqual(find('node_modules'), ['node_modules'], 'empty directory');
+  }
 });


### PR DESCRIPTION
Modify the nodeps install test to account for the npm3 behaviour of
creating an empty node_modules directory when there are no dependencies.